### PR TITLE
Check permissions

### DIFF
--- a/lib/PaginationEmbed.js
+++ b/lib/PaginationEmbed.js
@@ -98,6 +98,14 @@ class PaginationEmbed {
     }
 
     /**
+     * Check if the client can remove the reaction
+     * @returns {Boolean}
+     */
+    checkPerms() {
+        return this.message.channel.guild && this.message.channel.permissionsOf(this.message._client.user.id).has('manageMessages');
+    }
+
+    /**
      * Main method handling the reaction listening and content updating
      */
     run() {
@@ -105,7 +113,9 @@ class PaginationEmbed {
             switch (event.emoji.name) {
                 case this.firstPage: {
                     if (this.advanced) {
-                        await this.message.removeReaction(this.firstPage, this.invoker.author.id);
+                        if (this.checkPerms()) {
+                            await this.message.removeReaction(this.firstPage, this.invoker.author.id);
+                        }
 
                         if (this.page > 1) {
                             this.page = 1;
@@ -117,7 +127,9 @@ class PaginationEmbed {
                 }
 
                 case this.back: {
-                    await this.message.removeReaction(this.back, this.invoker.author.id);
+                    if (this.checkPerms()) {
+                        await this.message.removeReaction(this.back, this.invoker.author.id);
+                    }
 
                     if (this.page > 1) {
                         this.page--;
@@ -131,7 +143,9 @@ class PaginationEmbed {
                 }
 
                 case this.forth: {
-                    await this.message.removeReaction(this.forth, this.invoker.author.id);
+                    if (this.checkPerms()) {
+                        await this.message.removeReaction(this.forth, this.invoker.author.id);
+                    }
 
                     if (this.page < this.pages.length) {
                         this.page++;
@@ -146,7 +160,9 @@ class PaginationEmbed {
 
                 case this.lastPage: {
                     if (this.advanced) {
-                        await this.message.removeReaction(this.lastPage, this.invoker.author.id);
+                        if (this.checkPerms()) {
+                            await this.message.removeReaction(this.lastPage, this.invoker.author.id);
+                        }
 
                         if (this.page < this.pages.length) {
                             this.page = this.pages.length;
@@ -161,10 +177,14 @@ class PaginationEmbed {
 
                 case this.delete: {
                     if (this.advanced) {
-                        return new Promise((resolve) => {
-                            this.message.removeReactions().then(() => {
-                                resolve();
-                            });
+                        return new Promise((resolve, reject) => {
+                            if (this.checkPerms()) {
+                                this.message.removeReactions().then(() => {
+                                    resolve();
+                                });
+                            } else {
+                                reject(new Error('Insufficient permissions to remove reactions'))
+                            }
                         });
                     }
 


### PR DESCRIPTION
Checks if the client can remove the reaction before attempting to - allows the paginator to continue to work if unable to remove reaction
This also fixes #10 