### PR TITLE
more options for buttons

### DIFF
--- a/lib/PaginationEmbed.js
+++ b/lib/PaginationEmbed.js
@@ -11,9 +11,16 @@ const ReactionHandler = require('eris-reactions');
  * @property {Boolean} [cycling] Cycle through all embeds jumping from the first page to the last page on going back and from the last page to the first page going forth. Defaults to: false
  * @property {Number} [maxMatches] How often the reaction handler should listen for a reaction (How often the paginator can be used). Defaults to: 50. Maximum: 100
  * @property {Number} [timeout] How long the paginator should work before the reaction listener times out. Defaults to: 300000ms (5 minutes). Maximum: 900000ms (15 minutes)
- * @property {String} [deleteButton] Emoji which should be used as the delete button. This MUST be a unicode emoji! Defaults to: 🗑
- * @property {String} [firstButton] Emoji which should be used as the first page button. This MUST be a unicode emoji! Defaults to: ⏮
- * @property {String} [lastButton] Emoji which should be used as the last page button. This MUST be a unicode emoji! Defaults to: ⏭
+ * 
+ * @property {Boolean} [deleteButton.enable] 
+ * @property {String} [deleteButton.emoji] Emoji which should be used as the delete button. This MUST be a unicode emoji! Defaults to: 🗑
+ * 
+ * @property {Boolean} [firstButton.enable] 
+ * @property {String} [firstButton.emoji] Emoji which should be used as the first page button. This MUST be a unicode emoji! Defaults to: ⏮
+ * 
+ * @property {Boolean} [firstButton.enable]
+ * @property {String} [firstButton.emoji] Emoji which should be used as the last page button. This MUST be a unicode emoji! Defaults to: ⏭
+ * 
  * @property {String} [backButton] Emoji which should be used as the back button. This MUST be a unicode emoji! Defaults to: ⬅
  * @property {String} [forthButton] Emoji which should be used as the forth button. This MUST be a unicode emoji! Defaults to: ➡
  * @property {Number} [startPage] Which page of the submitted embed array should be shown first. Defaults to: 1 (The 1st page / element in the array)
@@ -34,17 +41,24 @@ class PaginationEmbed {
         this.pages      = pages;
         this.invoker    = message;
         this.options    = options;
-        this.delete     = options.deleteButton  || '🗑';
-        this.firstPage  = options.firstButton   || '⏮';
-        this.lastPage   = options.lastButton    || '⏭';
+        
+        this.delete = {enable: options.deleteButton.enable || false, emoji: options.deleteButton?.emoji || '🗑'}
+        
+        this.firstPage = {enable: options.firstButton?.enable || false, emoji: options.firstButton?.emoji || '⏮'}
+        
+        this.lastPage = {enable: options.lastButton?.enable || false, emoji: options.lastButton?.emoji || '⏭'}
+
         this.back       = options.backButton    || '⬅';
         this.forth      = options.forthButton   || '➡';
+
         this.page       = options.startPage     || 1;
         this.maxMatches = options.maxMatches    || 50;
         this.timeout    = options.timeout       || 300000;
         this.cycling    = options.cycling       || false
-        this.showPages  = (typeof options.showPageNumbers !== 'undefined') ? options.showPageNumbers : true;
-        this.advanced   = (typeof options.extendedButtons !== 'undefined') ? options.extendedButtons : false;
+
+        this.showPages = typeof options.showPageNumbers == "boolean" ? options.showPageNumbers : options.showPageNumbers.footer ? options.showPageNumbers : false;
+
+        this.advanced = options.extendedButtons != true ? false : true;
     }
 
     /**
@@ -68,9 +82,17 @@ class PaginationEmbed {
             return Promise.reject(new Error('Embed Timeout too high! Maximum pagination lifespan allowed is 15 minutes (900000 ms)!'));
         }
 
-        const messageContent = {
-            content: (this.showPages) ? `Page **${this.page}** of **${this.pages.length}**` : undefined,
+        let messageContent = {
             embed: this.pages[this.page - 1]
+        }
+
+        // Handle showPage appearing in footer or content
+        if(this.showPages.footer && this.showPages.footer == true) {
+         (this.pages).forEach(item => {
+            item.footer = {text: `Page ${this.page} / ${this.pages.length}`}
+         })
+        } else if(this.showPages) {
+            messageContent.content = `Page **${this.page}** / **${this.pages.length}**`
         }
         
         if (this.invoker.author.id === this.invoker._client.user.id) {
@@ -82,11 +104,14 @@ class PaginationEmbed {
         this.handler = new ReactionHandler.continuousReactionStream(this.message, (userID) => userID === this.invoker.author.id, false, { maxMatches: this.maxMatches, time: this.timeout });
 
         if (this.advanced) {
-            await this.message.addReaction(this.firstPage);
+          this.firstPage.enable == true ? await this.message.addReaction(this.firstPage.emoji) : "";
+
             await this.message.addReaction(this.back);
             await this.message.addReaction(this.forth);
-            await this.message.addReaction(this.lastPage);
-            await this.message.addReaction(this.delete);
+
+          this.lastPage.enable == true ? await this.message.addReaction(this.lastPage.emoji) : "";
+
+          this.delete.enable == true ? await this.message.addReaction(this.delete.emoji) : "";
         } else {
             await this.message.addReaction(this.back);
             await this.message.addReaction(this.forth);
@@ -97,10 +122,16 @@ class PaginationEmbed {
      * Updates the embed's content with the new page
      */
     update() {
-        this.message.edit({
-            content: (this.showPages) ? `Page **${this.page}** of **${this.pages.length}**` : undefined,
-            embed: this.pages[this.page - 1]
-        });
+        let _messageContent = {
+            embed: this.pages[this.page-1],
+        }
+        // Handle showPage appearing in footer or content
+        if(this.showPages.footer && this.showPages.footer == true) {
+            this.pages[this.page-1].footer.text = `Page ${this.page} / ${this.pages.length}`
+        } else if(this.showPages) {
+            _messageContent.content = `Page **${this.page}** / **${this.pages.length}**`
+        }
+        this.message.edit(_messageContent);
     }
 
     /**
@@ -117,10 +148,10 @@ class PaginationEmbed {
     run() {
         this.handler.on('reacted', async (event) => {
             switch (event.emoji.name) {
-                case this.firstPage: {
+                case this.firstPage.emoji: {
                     if (this.advanced) {
                         if (this.checkPerms()) {
-                            await this.message.removeReaction(this.firstPage, this.invoker.author.id);
+                            await this.message.removeReaction(this.firstPage.emoji, this.invoker.author.id);
                         }
 
                         if (this.page > 1) {
@@ -164,10 +195,10 @@ class PaginationEmbed {
                     break;
                 }
 
-                case this.lastPage: {
+                case this.lastPage.emoji: {
                     if (this.advanced) {
                         if (this.checkPerms()) {
-                            await this.message.removeReaction(this.lastPage, this.invoker.author.id);
+                            await this.message.removeReaction(this.lastPage.emoji, this.invoker.author.id);
                         }
 
                         if (this.page < this.pages.length) {
@@ -181,7 +212,7 @@ class PaginationEmbed {
                     break;
                 }
 
-                case this.delete: {
+                case (this.delete.emoji): {
                     if (this.advanced) {
                         return new Promise((resolve, reject) => {
                             if (this.checkPerms()) {


### PR DESCRIPTION
All the new stuff below seems to work properly as far as I can tell. I did my best at optimizing everything, I probably missed some stuff though.

1. "deleteButton", "firstButton", & "lastButton" changed from Booleans to Objects containing "enable" & "emoji".
   a. Each extended button can be enabled individually and function as intended on your messages
   b. "emoji" overrides the default like before
   c. "extendedButtons" still needs to be set to 'true' for these to work

2. "showPageNumbers" has the option of changing from content to footer by specifying {footer: true} rather than a straight Boolean.

Example:
              EmbedPaginator.createPaginationEmbed(msg, embeds, {
                showPageNumbers: {footer: true},
                extendedButtons: true,
                firstButton: {enable: true, emoji: "🔁"},
                lastButton: {enable: false},
                deleteButton: {enable: true}
              });